### PR TITLE
Extend Device Model to include name, earnings and formatted bandwidth

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ All additional arguements are passed on to the `requests.method` call.
         --- | ---
         `uuid` | UUID of the device.
         `bandwidth_usage` | Unredeemed bandwidth usage.
-        `total_bandwidth` | Total bandwindth usage.
+        `total_bandwidth_usage` | Total bandwidth usage.
         `redeemed_bandwidth` | Redeemed bandwidth usage.
         `rate` | Price/GB of the device.
         `country` | Country of the device.

--- a/README.md
+++ b/README.md
@@ -83,17 +83,24 @@ All additional arguements are passed on to the `requests.method` call.
         `windows_devices` | Number of Windows devices.
         `linux_devices` | Number of Linux devices.
         `other_devices` | Number of other type of devices.
-        `total_bandwidth_usage` | Shows bandwidth usage of all devices combined
+        `total_bandwidth_usage` | Shows bandwidth usage of all devices combined in bytes.
+        `total_bandwidth_usage_formatted` | Shows bandwidth usage of all devices combined as friendly string e.g. 2.4GB.
 
     - The object `Device` has the following attributes.
 
         Attribute | Description
         --- | ---
         `uuid` | UUID of the device.
-        `bandwidth_usage` | Unredeemed bandwidth usage.
-        `total_bandwidth_usage` | Total bandwidth usage.
-        `redeemed_bandwidth` | Redeemed bandwidth usage.
+        `name` | Name of the device.
+        `bandwidth_usage` | Unredeemed bandwidth usage in bytes.
+        `bandwidth_usage_formatted` | Unredeemed bandwidth usage as friendly string e.g. 2.4GB.
+        `total_bandwidth_usage` | Total bandwidth usage in bytes.
+        `total_bandwidth_usage_formatted` | Total bandwidth usage as friendly string e.g. 2.4GB.
+        `redeemed_bandwidth` | Redeemed bandwidth usage in bytes.
+        `redeemed_bandwidth_formatted` | Redeemed bandwidth usage as friendly string e.g. 2.4GB.
         `rate` | Price/GB of the device.
+        `earned` | Unredeemed earnings for this device.
+        `earned_total` | Total earnings for this device.
         `country` | Country of the device.
         `device_type` | Type of device. (win/node/`None`)
 
@@ -166,7 +173,7 @@ All additional arguements are passed on to the `requests.method` call.
     ```python
     redeem_to_paypal(paypal_email = 'someone@example.com')
     ```
-    - Returns `true` on successfull redeem, else `False`.
+    - Returns `true` on successful redeem, else `False`.
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ All additional arguements are passed on to the `requests.method` call.
         `last_name` | User's last name
         `name` | User's full name
         `email` | User's login email
+        `onboarding` | User's registration timestamp
 
 
 2. Get information on user's earnings.

--- a/pyEarnapp/__init__.py
+++ b/pyEarnapp/__init__.py
@@ -1,3 +1,3 @@
 from .earnapp import EarnApp, Device, Transaction, RedeemDetails, Referee
-VERSION = '0.0.16.1'
+VERSION = '0.0.17.0'
 print(f"API Version: {VERSION}")

--- a/pyEarnapp/models/device.py
+++ b/pyEarnapp/models/device.py
@@ -1,6 +1,9 @@
-from ..report import report_banned_ip
 import re
 from typing import List
+
+from ..report import report_banned_ip
+from ..tools import format_bytes
+
 
 class BanDetails:
     def __init__(self, ban_info) -> None:
@@ -17,16 +20,22 @@ class BanDetails:
 
 
 class Device:
-    def __init__(self, json_device_info: dict):
+    def __init__(self, json_device_info: dict):        
+        self.name = json_device_info.get("title", "Error retrieving Name")
         self.uuid = json_device_info.get("uuid", "Error retrieving UUID")
         self.bandwidth_usage = json_device_info.get("bw", 0)
+        self.bandwidth_usage_formatted = format_bytes(self.bandwidth_usage)
         self.total_bandwidth_usage = json_device_info.get(
-            "total_bw", "Error retrieving total bandwidth")
+            "total_bw", 0)
+        self.total_bandwidth_usage_formatted = format_bytes(self.total_bandwidth_usage)
         self.redeemed_bandwidth = json_device_info.get(
-            "redeem_bw", "Error retrieving redeemed bandwidth")
+            "redeem_bw", 0)
+        self.redeemed_bandwidth_formatted = format_bytes(self.redeemed_bandwidth)
         self.rate = json_device_info.get("rate", "Error retrieving rate")
         self.country = json_device_info.get("cn", "UnKnown")
         self.device_type = re.findall('sdk-([a-zA-Z0-9]*)-', self.uuid)[0]
+        self.earned = json_device_info.get("earned", 0)
+        self.earned_total = json_device_info.get("earned_total", 0)
         self.banned = BanDetails(json_device_info.get('banned', False))
 
 
@@ -58,6 +67,8 @@ class DevicesInfo:
                 self.banned_ip_addresses.append(device.banned.ip)
         if report_ip_ban:
             report_banned_ip(self.banned_ip_addresses)
+        
+        self.total_bandwidth_usage_formatted = format_bytes(self.total_bandwidth_usage)
 
     def get_devices(self) -> List[Device]:
         return self.devices

--- a/pyEarnapp/models/user.py
+++ b/pyEarnapp/models/user.py
@@ -6,3 +6,4 @@ class UserData:
         self.name = json_user_data.get("name", None)
         self.email = json_user_data.get("email", None)
         self.referral_code = json_user_data.get("referral_code", None)
+        self.onboarding = json_user_data.get("onboarding", None)

--- a/pyEarnapp/tools.py
+++ b/pyEarnapp/tools.py
@@ -10,3 +10,12 @@ def is_a_valid_ip(ipaddress:str):
     if(re.search(regex, ipaddress)):
         return True
     return False
+
+def format_bytes(size):
+    power = 2**10
+    n = 0
+    power_labels = {0: '', 1: 'K', 2: 'M', 3: 'G', 4: 'T'}
+    while size > power:
+        size /= power
+        n += 1
+    return '{:.2f}'.format(size) + power_labels[n]+'B'


### PR DESCRIPTION
This is a small PR to extend the Device model to include a few missing properties from the EarnApp dashboard API. I've also added some nice formatted properties for display purposes.